### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,24 +1,26 @@
 {
-  "name": "cloudkms",
-  "name_pretty": "Google Cloud Key Management Service",
-  "product_documentation": "https://cloud.google.com/kms",
-  "client_documentation": "https://googleapis.dev/python/cloudkms/latest",
-  "issue_tracker": "https://issuetracker.google.com/savedsearches/5264932",
-  "release_level": "ga",
-  "language": "python",
-  "library_type": "GAPIC_AUTO",
-  "repo": "googleapis/python-kms",
-  "distribution_name": "google-cloud-kms",
-  "api_id": "cloudkms.googleapis.com",
-  "requires_billing": true,
-  "client_library": true,
-  "custom_content": "The Google Cloud KMS API is a service that allows you to keep encryption keys centrally in the cloud, for direct use by cloud services. More info about Cloud KMS can be found at https://cloud.google.com/kms/docs/",
-  "sample_project_dir": "samples/snippets/",
-  "samples": [
-    {"name": "Quickstart",
-      "description": "This quickstart shows you how to create and use encryption keys with Cloud Key Management Service.",
-      "file": "quickstart.py",
-      "runnable": true,
-      "custom_content": "More information about the Cloud KMS quickstart is available at https://cloud.google.com/kms/docs/quickstart"}
-  ]
+    "name": "cloudkms",
+    "name_pretty": "Google Cloud Key Management Service",
+    "product_documentation": "https://cloud.google.com/kms",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/cloudkms/latest",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/5264932",
+    "release_level": "ga",
+    "language": "python",
+    "library_type": "GAPIC_AUTO",
+    "repo": "googleapis/python-kms",
+    "distribution_name": "google-cloud-kms",
+    "api_id": "cloudkms.googleapis.com",
+    "requires_billing": true,
+    "client_library": true,
+    "custom_content": "The Google Cloud KMS API is a service that allows you to keep encryption keys centrally in the cloud, for direct use by cloud services. More info about Cloud KMS can be found at https://cloud.google.com/kms/docs/",
+    "sample_project_dir": "samples/snippets/",
+    "samples": [
+        {
+            "name": "Quickstart",
+            "description": "This quickstart shows you how to create and use encryption keys with Cloud Key Management Service.",
+            "file": "quickstart.py",
+            "runnable": true,
+            "custom_content": "More information about the Cloud KMS quickstart is available at https://cloud.google.com/kms/docs/quickstart"
+        }
+    ]
 }


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.