### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "cloudkms",
     "name_pretty": "Google Cloud Key Management Service",
     "product_documentation": "https://cloud.google.com/kms",
-    "client_documentation": "https://googleapis.dev/python/cloudkms/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/cloudkms/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/5264932",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ cloud resources and applications.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-kms.svg
    :target: https://pypi.org/project/google-cloud-kms/
 .. _Cloud Key Management Service (KMS) API: https://cloud.google.com/kms
-.. _Client Library Documentation: https://googleapis.dev/python/cloudkms/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/cloudkms/latest
 .. _Product Documentation:  https://cloud.google.com/kms
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.